### PR TITLE
Falling back to 127.0.0.1 for mongodb url if process.env.IP is not available

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -4,7 +4,7 @@ var monk = require('monk');
 var constants = require('../constants');
 
 var
-    url = 'mongodb://' + process.env.IP + '/lrs',
+    url = 'mongodb://' + (process.env.IP || '127.0.0.1') + '/lrs',
     db = monk(url, { connectTimeoutMS: constants.dbConnectionTimeout, socketTimeoutMS: constants.dbSocketTimeout }),
     statements = db.get('statements'),
     results = db.get('results');


### PR DESCRIPTION
In the effort of updating the LRS to run in a simpler setup (for example, without IIS), removing the dependency on an env var named 'IP' to define the mongodb url