### PR TITLE
add support for MONGO_URI environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@
     `node migration/exec.js`
 
 ### Using a different server to host Mongodb
-If your mongodb instance is hosted under a non-default location, set the `DBHOST` and `DBNAME` environment variables, and the lrs will connect to `mongodb://${DBHOST}/${DBNAME}` instead.
+If your mongodb instance is hosted under a non-default location, set the `MONGO_URI` environment variable.
+Or, set the `DBHOST` and `DBNAME` environment variables, and the lrs will connect to `mongodb://${DBHOST}/${DBNAME}` instead.
 For example, in the IIS config, simply add `<app key="DBHOST" value="..." />` and `<app key="DBNAME" value="..." />` to the `<appSettings>` element.
 
 Resources

--- a/db/index.js
+++ b/db/index.js
@@ -6,7 +6,7 @@ var constants = require('../constants');
 var
     dbhost = (process.env.DBHOST || process.env.IP || '127.0.0.1'),
     dbname = (process.env.DBNAME || 'lrs'),
-    url = 'mongodb://' + dbhost + '/' + dbname,
+    url = (process.env.MONGO_URI || 'mongodb://' + dbhost + '/' + dbname),
     db = monk(url, { connectTimeoutMS: constants.dbConnectionTimeout, socketTimeoutMS: constants.dbSocketTimeout }),
     statements = db.get('statements'),
     results = db.get('results');


### PR DESCRIPTION
This enables connecting to more advanced mongo servers with support for things like:

- username/password
- replicaSet configuration
- custom database name

i.e. mongodb://**username:password**@**host1:port1,host2:port2**/**dbname**?**replicaSet=replicaSetName**