### PR TITLE
add support for basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@
 If your mongodb instance is hosted under a non-default location, set the `DBHOST` and `DBNAME` environment variables, and the lrs will connect to `mongodb://${DBHOST}/${DBNAME}` instead.
 For example, in the IIS config, simply add `<app key="DBHOST" value="..." />` and `<app key="DBNAME" value="..." />` to the `<appSettings>` element.
 
+### Securing the LRS
+If you set the `AUTH_USER` and `AUTH_PASSWORD` environment variables, the LRS will prompt for and require basic authentication credentials for all xAPI requests.
+
 Resources
 -----------
 1. [Hosting node.js applications in IIS on Windows](https://github.com/tjanczuk/iisnode)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "co-body": "^1.0.0",
     "koa": "^0.13.0",
+    "koa-basic-auth": "^1.1.2",
     "koa-compress": "^1.0.8",
     "koa-logger": "^1.2.2",
     "koa-route": "^2.2.0",


### PR DESCRIPTION
This uses the koa-basic-auth npm module (https://www.npmjs.com/package/koa-basic-auth) to add (optional) support for requiring basic authentication credentials for all xAPI requests.

Set the `AUTH_USER` and `AUTH_PASSWORD` environment variables to enable the feature
